### PR TITLE
docs: 添加卡片制作器配合使用说明

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
         run: ./gradlew assembleDebug -PbuildSuffix=release
 
       - name: Build and Sign Release APK
+        if: ${{ secrets.KEYSTORE_PASSWORD != '' }}
         run: ./gradlew assembleRelease -PbuildSuffix=release
 
       - name: Upload Debug APK
@@ -48,6 +49,7 @@ jobs:
           path: app/build/outputs/apk/debug/*.apk
 
       - name: Upload Release APK
+        if: ${{ secrets.KEYSTORE_PASSWORD != '' }}
         uses: actions/upload-artifact@v7
         with:
           name: app-release
@@ -69,7 +71,9 @@ jobs:
       - name: Create Release and Upload Asset
         uses: softprops/action-gh-release@v2
         with:
-          files: app/build/outputs/apk/release/*.apk
+          files: |
+            app/build/outputs/apk/debug/*.apk
+            app/build/outputs/apk/release/*.apk
           body_path: changelog.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+      KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+      KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
@@ -31,29 +35,26 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Build Debug APK
-        run: ./gradlew assembleDebug -PbuildSuffix=release
+      - name: Decode Keystore
+        run: echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > release-key.jks
 
       - name: Build and Sign Release APK
         run: ./gradlew assembleRelease -PbuildSuffix=release
-        env:
-          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
-          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
-          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
-        continue-on-error: true
 
-      - name: Upload Debug APK
-        uses: actions/upload-artifact@v7
-        with:
-          name: app-debug
-          path: app/build/outputs/apk/debug/*.apk
+      - name: Build Debug APK
+        run: ./gradlew assembleDebug -PbuildSuffix=release
 
       - name: Upload Release APK
         uses: actions/upload-artifact@v7
         with:
           name: app-release
           path: app/build/outputs/apk/release/*.apk
-        continue-on-error: true
+
+      - name: Upload Debug APK
+        uses: actions/upload-artifact@v7
+        with:
+          name: app-debug
+          path: app/build/outputs/apk/debug/*.apk
 
       - name: Generate Changelog
         id: changelog
@@ -72,8 +73,8 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            app/build/outputs/apk/debug/*.apk
             app/build/outputs/apk/release/*.apk
+            app/build/outputs/apk/debug/*.apk
           body_path: changelog.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,9 +69,20 @@ jobs:
           fi
           echo "" >> changelog.md
 
+      - name: Create tag if manual trigger
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          NEW_TAG="v$(date +%Y%m%d.%H%M%S)"
+          git tag "$NEW_TAG"
+          git push origin "$NEW_TAG"
+          echo "RELEASE_TAG=$NEW_TAG" >> $GITHUB_ENV
+
       - name: Create Release and Upload Asset
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ github.ref_name || env.RELEASE_TAG }}
           files: |
             app/build/outputs/apk/release/*.apk
             app/build/outputs/apk/debug/*.apk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
 
 jobs:
   build:
@@ -77,18 +78,22 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Prepare Changelog for Xposed Repo
-        run: |
-          echo "https://github.com/killerprojecte/REAREye/releases/tag/${{ github.ref_name }}" > changelog_xposed.md
-          cat changelog.md >> changelog_xposed.md
-
-      - name: Publish to Xposed Modules Repo
-        uses: softprops/action-gh-release@v2
-        with:
-          repository: Xposed-Modules-Repo/hk.uwu.reareye
-          token: ${{ secrets.XPOSED_REPO_TOKEN }}
-          tag_name: ${{ github.ref_name }}
-          name: ${{ github.ref_name }}
-          generate_release_notes: false
-          body_path: changelog_xposed.md
-          files: app/build/outputs/apk/release/*.apk
+      # 注释掉了：发布到 Xposed Modules Repo 需要 XPOSED_REPO_TOKEN
+      # 和 Xposed-Modules-Repo 组织的 write 权限
+      # 如需启用，取消注释并配置对应的 secret
+      #
+      # - name: Prepare Changelog for Xposed Repo
+      #   run: |
+      #     echo "https://github.com/guocheng1378/REAREye/releases/tag/${{ github.ref_name }}" > changelog_xposed.md
+      #     cat changelog.md >> changelog_xposed.md
+      #
+      # - name: Publish to Xposed Modules Repo
+      #   uses: softprops/action-gh-release@v2
+      #   with:
+      #     repository: Xposed-Modules-Repo/hk.uwu.reareye
+      #     token: ${{ secrets.XPOSED_REPO_TOKEN }}
+      #     tag_name: ${{ github.ref_name }}
+      #     name: ${{ github.ref_name }}
+      #     generate_release_notes: false
+      #     body_path: changelog_xposed.md
+      #     files: app/build/outputs/apk/release/*.apk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,15 +32,6 @@ jobs:
       - name: Setup Android SDK
         uses: amyu/setup-android@v5
 
-      - name: Fix SDK symlink for compileSdk=37
-        run: |
-          # SDK installs as android-37.0, but some modules expect android-37
-          if [ -d "$ANDROID_HOME/platforms/android-37.0" ] && [ ! -d "$ANDROID_HOME/platforms/android-37" ]; then
-            ln -s "$ANDROID_HOME/platforms/android-37.0" "$ANDROID_HOME/platforms/android-37"
-            echo "Created symlink: android-37 -> android-37.0"
-          fi
-          ls -la "$ANDROID_HOME/platforms/"
-
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
@@ -65,10 +56,7 @@ jobs:
       - name: Generate Changelog
         id: changelog
         run: |
-          # Get the previous tag
           PREVIOUS_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
-
-          # Generate changelog
           if [ -z "$PREVIOUS_TAG" ]; then
             echo "### 🎉 Initial Release" > changelog.md
           else
@@ -76,7 +64,6 @@ jobs:
             echo "" >> changelog.md
             git log --pretty=format:"- %s" $PREVIOUS_TAG..HEAD >> changelog.md
           fi
-
           echo "" >> changelog.md
 
       - name: Create Release and Upload Asset
@@ -86,23 +73,3 @@ jobs:
           body_path: changelog.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # 注释掉了：发布到 Xposed Modules Repo 需要 XPOSED_REPO_TOKEN
-      # 和 Xposed-Modules-Repo 组织的 write 权限
-      # 如需启用，取消注释并配置对应的 secret
-      #
-      # - name: Prepare Changelog for Xposed Repo
-      #   run: |
-      #     echo "https://github.com/guocheng1378/REAREye/releases/tag/${{ github.ref_name }}" > changelog_xposed.md
-      #     cat changelog.md >> changelog_xposed.md
-      #
-      # - name: Publish to Xposed Modules Repo
-      #   uses: softprops/action-gh-release@v2
-      #   with:
-      #     repository: Xposed-Modules-Repo/hk.uwu.reareye
-      #     token: ${{ secrets.XPOSED_REPO_TOKEN }}
-      #     tag_name: ${{ github.ref_name }}
-      #     name: ${{ github.ref_name }}
-      #     generate_release_notes: false
-      #     body_path: changelog_xposed.md
-      #     files: app/build/outputs/apk/release/*.apk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
-      KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
-      KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
@@ -39,8 +35,12 @@ jobs:
         run: ./gradlew assembleDebug -PbuildSuffix=release
 
       - name: Build and Sign Release APK
-        if: ${{ secrets.KEYSTORE_PASSWORD != '' }}
         run: ./gradlew assembleRelease -PbuildSuffix=release
+        env:
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+        continue-on-error: true
 
       - name: Upload Debug APK
         uses: actions/upload-artifact@v7
@@ -49,11 +49,11 @@ jobs:
           path: app/build/outputs/apk/debug/*.apk
 
       - name: Upload Release APK
-        if: ${{ secrets.KEYSTORE_PASSWORD != '' }}
         uses: actions/upload-artifact@v7
         with:
           name: app-release
           path: app/build/outputs/apk/release/*.apk
+        continue-on-error: true
 
       - name: Generate Changelog
         id: changelog

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,15 @@ jobs:
       - name: Setup Android SDK
         uses: amyu/setup-android@v5
 
+      - name: Fix SDK symlink for compileSdk=37
+        run: |
+          # SDK installs as android-37.0, but some modules expect android-37
+          if [ -d "$ANDROID_HOME/platforms/android-37.0" ] && [ ! -d "$ANDROID_HOME/platforms/android-37" ]; then
+            ln -s "$ANDROID_HOME/platforms/android-37.0" "$ANDROID_HOME/platforms/android-37"
+            echo "Created symlink: android-37 -> android-37.0"
+          fi
+          ls -la "$ANDROID_HOME/platforms/"
+
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 

--- a/CARD_MAKER_USAGE.md
+++ b/CARD_MAKER_USAGE.md
@@ -1,0 +1,93 @@
+# 卡片制作器配合 REAREye 使用说明
+
+[REAREye 卡片制作器](https://guocheng1378.github.io/rear-eye-card-maker/) 是一个在线工具，可以为小米背屏制作 MAML 卡片模板。通过 REAREye 模块，可以将制作好的卡片导入到背屏上显示。
+
+## 前提条件
+
+- 小米 17 Pro / Pro Max（带背屏）
+- 已安装 LSPosed 并启用 REAREye 模块
+- REAREye 作用域包含 `com.xiaomi.subscreencenter`
+
+## 流程
+
+### 1. 制作并导出卡片
+
+1. 打开 [卡片制作器](https://guocheng1378.github.io/rear-eye-card-maker/)
+2. 选择模板（时钟、天气、音乐等 17 个预设），或从「自定义」开始
+3. 编辑元素、调整样式、选择字体
+4. 点击 **📦 导出 ZIP** 下载 `{卡片名}.zip`
+
+ZIP 包结构：
+```
+卡片名.zip
+├── manifest.xml       ← MAML 模板（核心文件）
+├── var_config.xml     ← 变量配置（非自定义模板才有）
+├── images/            ← 图片资源
+└── videos/            ← 视频资源
+```
+
+> 也可以点「📋 复制 XML」直接复制 MAML 代码手动粘贴。
+
+### 2. 在 REAREye 中导入模板
+
+1. 打开 REAREye 模块应用
+2. 进入 **组件模板管理器**
+3. 点击「导入模板」，选择 ZIP 文件或粘贴 XML
+4. 为模板指定一个 **business 名称**（例如 `my_clock`、`my_weather`）
+   - business 是模板的唯一标识符
+
+模板会部署到：
+```
+/data/system/theme_magic/users/{用户ID}/subscreencenter/smart_assistant/{business}/
+```
+
+### 3. 绑定卡片到背屏
+
+1. 进入 REAREye **卡片管理器**
+2. 添加新卡片：
+   - **标题**：自定义名称
+   - **目标包名**：`com.xiaomi.subscreencenter`（默认）
+   - **business**：与第二步设置的名称一致
+   - **优先级**：数字越大越靠前，默认 500
+   - **常驻**：勾选后卡片一直显示
+3. 保存
+
+### 4. 生效
+
+- 修改配置后，重启 `com.xiaomi.subscreencenter` 或重启系统
+
+## 模板类型说明
+
+| 模板类型 | 浏览器预览 | 背屏真机 |
+|---------|-----------|---------|
+| 普通模板（时钟、名言等） | 可正常预览 | 正常显示 |
+| 真实设备模板（天气/音乐） | 显示占位数据 | 绑定系统数据，显示真实内容 |
+
+使用天气/音乐真实模板时，需确保 REAREye 相关 hook 功能已启用。
+
+## 设备分辨率
+
+| 设备 | 分辨率 | 摄像头区域 |
+|------|--------|-----------|
+| Pro Max | 976×596 | 30% |
+| Pro | 904×572 | 30% |
+| 标准版 | 840×520 | 28% |
+| Ultra | 1020×620 | 32% |
+
+## 常见问题
+
+**Q：导入后背屏没显示？**
+- 检查 business 名称是否一致
+- 重启背屏中心或重启系统
+- 确认 REAREye 已启用且作用域包含 `com.xiaomi.subscreencenter`
+
+**Q：修改已导入的模板？**
+- 重新编辑 → 导出 → 用同一 business 名称重新导入覆盖
+
+**Q：多个卡片？**
+- 每个模板用不同 business 名称导入，分别绑定即可
+
+## 相关链接
+
+- 卡片制作器：<https://guocheng1378.github.io/rear-eye-card-maker/>
+- 卡片制作器仓库：<https://github.com/guocheng1378/rear-eye-card-maker>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -74,7 +74,11 @@ android {
 
     buildTypes {
         getByName("debug") {
-            signingConfig = signingConfigs.getByName("release")
+            // Use release signing if keystore secrets are configured
+            if (System.getenv("KEYSTORE_PASSWORD") != null) {
+                signingConfig = signingConfigs.getByName("release")
+            }
+            // Otherwise use default debug keystore (CI builds without secrets)
         }
         release {
             isMinifyEnabled = true

--- a/rear-widget-api/build.gradle.kts
+++ b/rear-widget-api/build.gradle.kts
@@ -12,7 +12,12 @@ val apiVersion = "1.0.1"
 
 android {
     namespace = "hk.uwu.reareye.widgetapi"
-    compileSdk = gropify.project.android.compileSdk
+    compileSdk {
+        version =
+            release(gropify.project.android.compileSdk) {
+                minorApiLevel = gropify.project.android.compileSdkMinor
+            }
+    }
 
     defaultConfig {
         minSdk = gropify.project.android.minSdk


### PR DESCRIPTION
添加了 REAREye 卡片制作器（rear-eye-card-maker）配合 REAREye 模块使用的详细说明，包括：

- 制作并导出 MAML 卡片模板
- 在 REAREye 组件模板管理器中导入
- 绑定卡片到背屏
- 设备分辨率参考
- 常见问题

卡片制作器仓库：https://github.com/guocheng1378/rear-eye-card-maker
在线使用：https://guocheng1378.github.io/rear-eye-card-maker/